### PR TITLE
Keep agents with free sockets in pool

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,11 @@ function agentFactory(BaseAgent) {
     Agent.prototype.removeSocket = function() {
         var res = Agent.super_.prototype.removeSocket.apply(this, arguments);
 
-        if (Object.keys(this.requests).length === 0 && Object.keys(this.sockets).length === 0) {
+        if (
+            Object.keys(this.requests).length === 0
+            && Object.keys(this.sockets).length === 0
+            && (this.freeSockets === undefined || Object.keys(this.freeSockets).length === 0)
+        ) {
             delete Agent.pool[this.name];
         }
 


### PR DESCRIPTION
Hello from the past!
We're still using asker and recently encountered a problem with keep-alive connections (they didn't work).

If keepAlive is used, Agent will call `this.removeSocket` on the sockets
being freed to reuse them in future.
But asker-advanced-agent removes Agent from pool if it has no `requests`
or `sockets` and those free sockets would never been reused.
Thus, I've added counting `this.freeSockets` to this logic.

After this, socket will be removed from `freeSockets` after `destroy()` and Agent will
be freed from the pool after that.

additional check on `this.freeSockets` has been added because
asker-advanced-agent supports node^0.10 and `freeSockets` was added in
0.11